### PR TITLE
fix: cache-bust google api calls

### DIFF
--- a/src/definitions/google-analytics-embed-api.d.ts
+++ b/src/definitions/google-analytics-embed-api.d.ts
@@ -973,6 +973,8 @@ export interface Query {
   callback?: string;
   /** Optional. Used for OAuth 1.0a authorization to specify your application to get quota. For example: key=AldefliuhSFADSfasdfasdfASdf. */
   key?: string;
+
+  z?: number;
 }
 
 export interface Chart {

--- a/src/stores/gapi.ts
+++ b/src/stores/gapi.ts
@@ -52,6 +52,7 @@ export const getDataReport = (
         'start-date': dateRange.from,
         'end-date': dateRange.to,
         filter: gaQueryFilter,
+        z: new Date().valueOf(), // cache-bust
       },
     });
     data
@@ -111,7 +112,10 @@ export const insertDataChart = (
 ): Promise<void> => {
   return new Promise(function (resolve, reject) {
     const chart = new (getGapi().analytics.googleCharts.DataChart)({
-      query,
+      query: {
+        ...query,
+        z: new Date().valueOf(), // cache-bust
+      },
       chart: {
         type: type,
         container: containerId,


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Google API responses can be cached in the browser

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- added google api cache busting (`z` query param that has the current time)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR -->
