### PR TITLE
fix(ga config): updated to be consistent and expect ga: to be prepended to fields in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Additional environments vars
 | BREAKDOWN_CHART_TITLE          | Breakdown chart title                                                            | Breakdown chart                      |
 | BREAKDOWN_CHART_DIMENSION      | Dimension for the chart                                                          | ga:deviceCategory                    |
 | GOOGLE_ANALYTICS_CLIENT_ID     | Google Analytics Client ID                                                       | abc123.apps.googleusercontent.com    |
-| GOOGLE_ANALYTICS_VIEW_ID       | Google Analytics View ID                                                         | 1234567890                           |
+| GOOGLE_ANALYTICS_VIEW_ID       | Google Analytics View ID                                                         | ga:1234567890                        |
 | GOOGLE_ANALYTICS_LOCALE        | Google Analytics View ID                                                         | en-GB                                |
 | GOOGLE_ANALYTICS_CURRENCY_CODE | Google Analytics View ID                                                         | GBP                                  |
 | GOOGLE_ANALYTICS_TIMEOUT       | Timeout used to determine how long we should wait before retrying a gapi request | 2000                                 |
@@ -54,7 +54,7 @@ LOCATION_HREF=http://localhost:3000
 BREAKDOWN_CHART_TITLE=Device Breakdown
 BREAKDOWN_CHART_DIMENSION=ga:deviceCategory
 GOOGLE_ANALYTICS_CLIENT_ID=abc123.apps.googleusercontent.com
-GOOGLE_ANALYTICS_VIEW_ID=1234567890
+GOOGLE_ANALYTICS_VIEW_ID=ga:1234567890
 GOOGLE_ANALYTICS_LOCALE=en-GB
 GOOGLE_ANALYTICS_CURRENCY_CODE=GBP
 GOOGLE_ANALYTICS_TIMEOUT=2000
@@ -86,11 +86,11 @@ To use the application the following permissions must be enabled:
 ```json
 {
   "googleAnalyticsClientId": "abc123.apps.googleusercontent.com",
-  "googleAnalyticsViewId": "1234567890",
+  "googleAnalyticsViewId": "ga:1234567890",
   "mappings": {
-    "contentItemId": "dimension1",
-    "editionId": "dimension2",
-    "slotId": "dimension3"
+    "contentItemId": "ga:dimension1",
+    "editionId": "ga:dimension2",
+    "slotId": "ga:dimension3"
   },
   "localization": {
     "locale": "en-GB",

--- a/src/components/date-range-picker/date-range-picker.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.spec.ts
@@ -4,8 +4,6 @@ import { tick } from 'svelte';
 import { dateRange } from '../../stores/date-range';
 import { formatDateAsISOString } from '../../utils/date-format';
 
-// jest.mock('svelte-flatpickr');
-
 describe('DateRangePicker', () => {
   it('should render a DateRangePicker inputs with the given date range', async () => {
     dateRange.set({

--- a/src/components/widgets/data-chart/data-chart.spec.ts
+++ b/src/components/widgets/data-chart/data-chart.spec.ts
@@ -21,12 +21,12 @@ describe('DataChart', () => {
     selectedEdition.set(null);
     dateRange.set({ from: '2020-11-01', to: '2020-11-02' });
     setGaConfig({
-      googleAnalyticsViewId: '1234567890',
+      googleAnalyticsViewId: 'ga:1234567890',
       googleAnalyticsClientId: '1234567890',
       mappings: {
-        contentItemId: 'dimension1',
-        editionId: 'dimension2',
-        slotId: 'dimension3',
+        contentItemId: 'ga:dimension1',
+        editionId: 'ga:dimension2',
+        slotId: 'ga:dimension3',
       },
     });
   });

--- a/src/components/widgets/data-chart/data-chart.svelte
+++ b/src/components/widgets/data-chart/data-chart.svelte
@@ -55,7 +55,7 @@
     const loadChart = async () => {
       await insertDataChart(
         {
-          ids: `ga:${$gaViewId}`,
+          ids: $gaViewId,
           metrics: 'ga:totalEvents,ga:uniqueEvents',
           dimensions,
           'start-date': $dateRange.from,

--- a/src/stores/gapi.spec.ts
+++ b/src/stores/gapi.spec.ts
@@ -14,10 +14,10 @@ describe('gapi', () => {
         )
       ).toMatchInlineSnapshot(`
         Object {
-          "dimensions": "ga:ga:dimension1",
+          "dimensions": "ga:dimension1",
           "end-date": "2020-12-31",
           "filters": "ga:dimension1=123",
-          "ids": "ga:ga:123",
+          "ids": "ga:123",
           "max-results": 20,
           "metrics": "ga:totalEvents,ga:uniqueEvents,ga:eventValue,ga:avgEventValue",
           "sort": "-ga:totalEvents",
@@ -39,10 +39,10 @@ describe('gapi', () => {
         )
       ).toMatchInlineSnapshot(`
         Object {
-          "dimensions": "ga:ga:dimension1",
+          "dimensions": "ga:dimension1",
           "end-date": "2020-12-31",
           "filters": undefined,
-          "ids": "ga:ga:123",
+          "ids": "ga:123",
           "max-results": 20,
           "metrics": "ga:totalEvents,ga:uniqueEvents,ga:eventValue,ga:avgEventValue",
           "sort": "-ga:totalEvents",

--- a/src/stores/gapi.ts
+++ b/src/stores/gapi.ts
@@ -50,9 +50,9 @@ export const buildDataReportQuery = (
   cacheBust: number = undefined
 ): Query => {
   return {
-    ids: `ga:${gaViewId}`,
+    ids: gaViewId,
     metrics: 'ga:totalEvents,ga:uniqueEvents,ga:eventValue,ga:avgEventValue',
-    dimensions: `ga:${dimension}`,
+    dimensions: dimension,
     sort: '-ga:totalEvents',
     'max-results': limit,
     'start-date': dateRange.from,


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Data reports prepend ga: to the field mappings from the extension configuration.

## What is the new behavior?

Removed the prepends so that it is expected ga: is added via the configuration instead and updated the README to reflect.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Configuration for existing dashboards will need to be updated to include the new prepended value.
