### PR TITLE
docs(readme): update hostnames 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Additional environments vars
 | Environment Var                   | Description                                                   | Example                                  |
 | --------------------------------- | ------------------------------------------------------------- | ---------------------------------------- |
 | API_URL                           | DC API URL                                                    | https://api.amplience.net/v2/content     |
-| AUTH_URL                          | Amplience Auth URL                                            | https://auth.adis.ws                     |
+| AUTH_URL                          | Amplience Auth URL                                            | https://auth.amplience.net                    |
 | HUB_ID                            | Hub ID                                                        | abcdef...                                |
 | CLIENT_ID                         | Client ID for the Hub                                         | abcdef...                                |
 | CLIENT_SECRET                     | Client Secret                                                 | abddef...                                |
@@ -172,7 +172,7 @@ CLIENT_ID=abcdef
 CLIENT_SECRET=abcdef
 HUB_ID=abcdef
 API_URL=https://api.amplience.net/v2/content
-AUTH_URL=https://auth.adis.ws
+AUTH_URL=https://auth.amplience.net
 LOCATION_HREF=http://localhost:3000
 BREAKDOWN_CHART_TITLE=Device Breakdown
 BREAKDOWN_CHART_DIMENSION=ga:deviceCategory


### PR DESCRIPTION
Updated references from auth.adis.ws to auth.amplience.net

## Pull request type

Documentation content changes

## What is the current behavior?

Links in the readme point to deprecated .ws domains.

## What is the new behavior?

Links have been updated to point to the new .net domains.
